### PR TITLE
chore: update jre 11 to latest patch, add zipfs

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -34,7 +34,9 @@ jdk.security.auth,\
 # sun.misc.Unsafe and friends
 jdk.unsupported,\
 # jdk specific network options
-jdk.net\
+jdk.net,\
+# zip, jar file systems
+jdk.zipfs\
  --output jre
 
 # We extract JRE's hard dependencies, libz and SSL certs, from the fat JRE image.

--- a/java-11/build.gradle.kts
+++ b/java-11/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("org.hypertrace.docker-publish-plugin")
 }
 
-var javaVersion = "11.0.8-11.41.23"
+var javaVersion = "11.0.10-11.45.27"
 
 hypertraceDocker {
   defaultImage {

--- a/java-14/Dockerfile
+++ b/java-14/Dockerfile
@@ -34,7 +34,9 @@ jdk.security.auth,\
 # sun.misc.Unsafe and friends
 jdk.unsupported,\
 # jdk specific network options
-jdk.net\
+jdk.net,\
+# zip, jar file systems
+jdk.zipfs\
  --output jre
 
 # We extract JRE's hard dependencies, libz and SSL certs, from the fat JRE image.


### PR DESCRIPTION
This updates the jre 11 base image to latest patch to pick up bugfixes. Also adds zipfs (<1MB) to image to support classpath scanning in e2e tests.