### PR TITLE
feat: add grpc health check binary

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -52,11 +52,15 @@ RUN ln -s /busybox/sh /bin/sh
 
 COPY --from=deps /etc/ssl/certs/java /etc/ssl/certs/java
 
-COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1.2.8
-RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1.2.11
+RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
 
 COPY --from=jre /jre /usr/lib/jvm/zulu-11-amd64-slim
 RUN ln -s /usr/lib/jvm/zulu-11-amd64-slim/bin/java /usr/bin/java
+
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.5 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
 
 # set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/zulu-11-amd64-slim

--- a/java-11/build.gradle.kts
+++ b/java-11/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("org.hypertrace.docker-publish-plugin")
 }
 
-var javaVersion = "11.0.10-11.45.27"
+var javaVersion = "11.0.12-11.50.19"
 
 hypertraceDocker {
   defaultImage {

--- a/java-14/Dockerfile
+++ b/java-14/Dockerfile
@@ -52,11 +52,15 @@ RUN ln -s /busybox/sh /bin/sh
 
 COPY --from=deps /etc/ssl/certs/java /etc/ssl/certs/java
 
-COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1.2.8
-RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1.2.11
+RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
 
 COPY --from=jre /jre /usr/lib/jvm/zulu-14-amd64-slim
 RUN ln -s /usr/lib/jvm/zulu-14-amd64-slim/bin/java /usr/bin/java
+
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.5 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
 
 # set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/zulu-14-amd64-slim


### PR DESCRIPTION
## Description
This change adds support for grpc based health checks as described in https://cloud.google.com/blog/topics/developers-practitioners/health-checking-your-grpc-servers-gke and https://github.com/grpc-ecosystem/grpc-health-probe/

The main goal of switching this from our current implementation is to get a more accurate response on health. Currently, we use a static, always true HTTP endpoint, however this continues to return true even if the GRPC server is no longer responding.

This change would add ~10MB to the base image size, moving from 106MB to 116MB (for java 11).

### Testing
Built an image locally with this and verified health check correctness.
