### PR TITLE
upgrade version of base debian image

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -42,6 +42,7 @@ jdk.zipfs\
 # We extract JRE's hard dependencies, libz and SSL certs, from the fat JRE image.
 FROM gcr.io/distroless/java:11-debug AS deps
 
+# Debian-11 image
 FROM gcr.io/distroless/cc:debug
 
 MAINTAINER Hypertrace "https://www.hypertrace.org/"
@@ -52,8 +53,8 @@ RUN ln -s /busybox/sh /bin/sh
 
 COPY --from=deps /etc/ssl/certs/java /etc/ssl/certs/java
 
-COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1.2.8
-RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1.2.11
+RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
 
 COPY --from=jre /jre /usr/lib/jvm/zulu-11-amd64-slim
 RUN ln -s /usr/lib/jvm/zulu-11-amd64-slim/bin/java /usr/bin/java

--- a/java-11/build.gradle.kts
+++ b/java-11/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("org.hypertrace.docker-publish-plugin")
 }
 
-var javaVersion = "11.0.10-11.45.27"
+var javaVersion = "11.0.13-11.52.13"
 
 hypertraceDocker {
   defaultImage {

--- a/java-14/Dockerfile
+++ b/java-14/Dockerfile
@@ -52,8 +52,8 @@ RUN ln -s /busybox/sh /bin/sh
 
 COPY --from=deps /etc/ssl/certs/java /etc/ssl/certs/java
 
-COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1.2.8
-RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.8 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=deps /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1.2.11
+RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
 
 COPY --from=jre /jre /usr/lib/jvm/zulu-14-amd64-slim
 RUN ln -s /usr/lib/jvm/zulu-14-amd64-slim/bin/java /usr/bin/java


### PR DESCRIPTION
The OS version of base image `gcr.io/distroless/cc:debug` is upgraded from Debian-9 to Debian-11.