### PR TITLE
fix: adding built in http client to available packages

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -35,6 +35,8 @@ jdk.security.auth,\
 jdk.unsupported,\
 # jdk specific network options
 jdk.net,\
+# built-in http client
+java.net.http,\
 # zip, jar file systems
 jdk.zipfs\
  --output jre

--- a/java-14/Dockerfile
+++ b/java-14/Dockerfile
@@ -35,6 +35,8 @@ jdk.security.auth,\
 jdk.unsupported,\
 # jdk specific network options
 jdk.net,\
+# built-in http client
+java.net.http,\
 # zip, jar file systems
 jdk.zipfs\
  --output jre


### PR DESCRIPTION
## Description
OK back to where we started - this is the original intended change (before it got pushed directly to main, which was already broken on container scanning)