### PR TITLE
Added jcmd jdk module for NM debuging

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -38,7 +38,9 @@ jdk.net,\
 # built-in http client
 java.net.http,\
 # zip, jar file systems
-jdk.zipfs\
+jdk.zipfs,\
+# jcmd module for NMT debugging
+jdk.jcmd\
  --output jre
 
 # We extract JRE's hard dependencies, libz and SSL certs, from the fat JRE image.
@@ -60,6 +62,9 @@ RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
 
 COPY --from=jre /jre /usr/lib/jvm/zulu-11-amd64-slim
 RUN ln -s /usr/lib/jvm/zulu-11-amd64-slim/bin/java /usr/bin/java
+
+# softlink for jcmd binary util
+RUN ln -s /usr/lib/jvm/zulu-11-amd64-slim/bin/jcmd  /usr/bin/jcmd
 
 # set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/zulu-11-amd64-slim

--- a/java-14/Dockerfile
+++ b/java-14/Dockerfile
@@ -38,7 +38,9 @@ jdk.net,\
 # built-in http client
 java.net.http,\
 # zip, jar file systems
-jdk.zipfs\
+jdk.zipfs,\
+# jcmd module for NMT debugging
+jdk.jcmd \
  --output jre
 
 # We extract JRE's hard dependencies, libz and SSL certs, from the fat JRE image.
@@ -59,6 +61,9 @@ RUN ln -s /lib/x86_64-linux-gnu/libz.so.1.2.11 /lib/x86_64-linux-gnu/libz.so.1
 
 COPY --from=jre /jre /usr/lib/jvm/zulu-14-amd64-slim
 RUN ln -s /usr/lib/jvm/zulu-14-amd64-slim/bin/java /usr/bin/java
+
+# Softlink for jcmd binary util
+RUN ln -s /usr/lib/jvm/zulu-14-amd64-slim/bin/jcmd /usr/bin/jcmd
 
 # set JAVA_HOME
 ENV JAVA_HOME=/usr/lib/jvm/zulu-14-amd64-slim


### PR DESCRIPTION
Adding jcmd module that is needed for NMT tracing capability on apps.

- Adding jcmd package will increase docker image size by ~1mb.
- Adding jcmd module will not enable the NMT tracking or add any overhead on the process performance.
- Enable/Disable NMT capability on the Java process will be handled with a Java_opts params in helm-values 
  eg: - name: JAVA_OPTS
           value: -XX:NativeMemoryTracking=summary 