### PR TITLE
Update base image sha to fix vulnerability (CVE-2022-48174) in busybox

### DIFF
--- a/java-11/base.image
+++ b/java-11/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:01fb4c3ba57bf2443fbfcc7967a223548f53c8f82a94f211104e735c39f38aae
+gcr.io/distroless/cc-debian12:debug@sha256:0a0d9b423154de754ee914ab1d3eefe8b394b08a8f21f96d75f8dec8e0d45df3

--- a/java-21/base.image
+++ b/java-21/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:01fb4c3ba57bf2443fbfcc7967a223548f53c8f82a94f211104e735c39f38aae
+gcr.io/distroless/cc-debian12:debug@sha256:0a0d9b423154de754ee914ab1d3eefe8b394b08a8f21f96d75f8dec8e0d45df3


### PR DESCRIPTION
````
We have a critical vulnerability in our base image coming from busybox and fixed in version fixed in 1.35+
Updated base image sha to fix vulnerability (CVE-2022-48174) in busybox

docker run --rm --entrypoint /busybox/sh gcr.io/distroless/cc-debian12:debug@sha256:0a0d9b423154de754ee914ab1d3eefe8b394b08a8f21f96d75f8dec8e0d45df3 -c "/busybox/busybox"

BusyBox v1.37.0 (2024-09-26 21:31:42 UTC) multi-call binary.
BusyBox is copyrighted by many authors between 1998-2015.
Licensed under GPLv2. See source distribution for detailed
copyright notices.

Busybox present in this one is 1.37.0 and doesnt have this critical vulnerability
````