### PR TITLE
chore: update base image due to vuln

### DIFF
--- a/java-11/base.image
+++ b/java-11/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:01fb4c3ba57bf2443fbfcc7967a223548f53c8f82a94f211104e735c39f38aae
+gcr.io/distroless/cc-debian12:debug@sha256:0a0d9b423154de754ee914ab1d3eefe8b394b08a8f21f96d75f8dec8e0d45df3

--- a/java-21/base.image
+++ b/java-21/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:01fb4c3ba57bf2443fbfcc7967a223548f53c8f82a94f211104e735c39f38aae
+gcr.io/distroless/cc-debian12:debug@sha256:0a0d9b423154de754ee914ab1d3eefe8b394b08a8f21f96d75f8dec8e0d45df3


### PR DESCRIPTION
Fix for CVE-2022-48174