### PR TITLE
feat: use latest debug image to get vulnerability fixes picked up

### DIFF
--- a/java-11/Dockerfile
+++ b/java-11/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 FROM azul/zulu-openjdk-debian:${JAVA_VERSION} AS jre
 
 # Needed for --strip-debug
-RUN apt-get -y update && apt-get -y upgrade libssl3 && apt-get -y install binutils
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install binutils
 
 # Included modules cherrypicked from https://docs.oracle.com/en/java/javase/11/docs/api/
 #

--- a/java-11/base.image
+++ b/java-11/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:22d266a557525a268a4c191b335ba786541e6f07bd7dfc4c5cba4db7828ecb50
+gcr.io/distroless/cc-debian12:debug

--- a/java-21/Dockerfile
+++ b/java-21/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 FROM azul/zulu-openjdk-debian:${JAVA_VERSION} AS jre
 
 # Needed for --strip-debug
-RUN apt-get -y update && apt-get -y upgrade libssl3 && apt-get -y install binutils
+RUN apt-get -y update && apt-get -y upgrade && apt-get -y install binutils
 
 # Included modules cherrypicked from https://docs.oracle.com/en/java/javase/21/docs/api/
 #

--- a/java-21/base.image
+++ b/java-21/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:22d266a557525a268a4c191b335ba786541e6f07bd7dfc4c5cba4db7828ecb50
+gcr.io/distroless/cc-debian12:debug


### PR DESCRIPTION
Instead of committing to a particular sha, would it be possible to use the latest image under this tag so that upstream vulnerability fixes gets automatically picked up?

For example this resolves these vulnerabilities of libssl3

- CVE-2025-15467
- CVE-2025-69420
- CVE-2025-69419