### PR TITLE
Update distroless base image for java images

### DIFF
--- a/java-11/base.image
+++ b/java-11/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:6490c1714f935ebed1af10f5c356efeef00c1fda958d9ba24484bc115380a011
+gcr.io/distroless/cc-debian12:debug@sha256:7bce0706fd152e9db0b8cfc4b58347efc0d13c38ac39651fb326a65f023f60b4

--- a/java-21/base.image
+++ b/java-21/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:6490c1714f935ebed1af10f5c356efeef00c1fda958d9ba24484bc115380a011
+gcr.io/distroless/cc-debian12:debug@sha256:7bce0706fd152e9db0b8cfc4b58347efc0d13c38ac39651fb326a65f023f60b4


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Upgrading base images to fix glibc vuln. 
```
crane digest gcr.io/distroless/cc-debian12:debug 
sha256:7bce0706fd152e9db0b8cfc4b58347efc0d13c38ac39651fb326a65f023f60b4
``` 