### PR TITLE
Update base image SHA256 digest

### DIFF
--- a/java-11/base.image
+++ b/java-11/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:7bce0706fd152e9db0b8cfc4b58347efc0d13c38ac39651fb326a65f023f60b4
+gcr.io/distroless/cc-debian12:debug@sha256:83cd6a79595b063961fc4c21814a7961e3f2741e94bfea8bde420898719e80c5

--- a/java-21/base.image
+++ b/java-21/base.image
@@ -1,1 +1,1 @@
-gcr.io/distroless/cc-debian12:debug@sha256:7bce0706fd152e9db0b8cfc4b58347efc0d13c38ac39651fb326a65f023f60b4
+gcr.io/distroless/cc-debian12:debug@sha256:83cd6a79595b063961fc4c21814a7961e3f2741e94bfea8bde420898719e80c5


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

Upgrading base images to address openssl vuln. 
```
crane digest gcr.io/distroless/cc-debian12:debug
sha256:83cd6a79595b063961fc4c21814a7961e3f2741e94bfea8bde420898719e80c5
``` 